### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/pystratum/Connection.py
+++ b/pystratum/Connection.py
@@ -27,7 +27,7 @@ class Connection:
             return_value = config.get(section, option, fallback=fallback)
 
         if fallback is None and return_value is None:
-            raise KeyError("Option '%s' is not found in section '%s'." % (option, section))
+            raise KeyError("Option '{0!s}' is not found in section '{1!s}'.".format(option, section))
 
         return return_value
 

--- a/pystratum/Constants.py
+++ b/pystratum/Constants.py
@@ -182,7 +182,7 @@ class Constants:
         """
         content = ''
         for constant, value in sorted(self._constants.items()):
-            content += "%s = %s\n" % (str(constant), str(value))
+            content += "{0!s} = {1!s}\n".format(str(constant), str(value))
 
             # Save the configuration file.
         Util.write_two_phases(self._config_filename, content)

--- a/pystratum/RoutineWrapperGenerator.py
+++ b/pystratum/RoutineWrapperGenerator.py
@@ -110,11 +110,11 @@ class RoutineWrapperGenerator:
         """
         Generate a class header for stored routine wrapper.
         """
-        self._write_line("from %s import %s" % (self._parent_class_namespace, self._parent_class_name))
+        self._write_line("from {0!s} import {1!s}".format(self._parent_class_namespace, self._parent_class_name))
         self._write_line()
         self._write_line()
         self._write_line('# ' + ('-' * 118))
-        self._write_line("class %s(%s):" % (self._wrapper_class_name, self._parent_class_name))
+        self._write_line("class {0!s}({1!s}):".format(self._wrapper_class_name, self._parent_class_name))
 
     # ------------------------------------------------------------------------------------------------------------------
     def _write_line(self, text=None):

--- a/pystratum/Util.py
+++ b/pystratum/Util.py
@@ -34,6 +34,6 @@ class Util:
             with open(tmp_filename, 'w+') as file:
                 file.write(the_data)
             os.replace(tmp_filename, the_filename)
-            print("Wrote: '%s'." % the_filename)
+            print("Wrote: '{0!s}'.".format(the_filename))
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/__init__.py
+++ b/pystratum/__init__.py
@@ -28,7 +28,7 @@ def create_constants(rdbms: str):
         module = locate('pystratum.pgsql.PgSqlConstants')
         return module.PgSqlConstants()
 
-    raise Exception("Unknown RDBMS '%s'." % rdbms)
+    raise Exception("Unknown RDBMS '{0!s}'.".format(rdbms))
 
 
 # ----------------------------------------------------------------------------------------------------------------------
@@ -56,7 +56,7 @@ def create_routine_loader(rdbms):
         module = locate('pystratum.pgsql.PgSqlRoutineLoader')
         return module.PgSqlRoutineLoader()
 
-    raise Exception("Unknown RDBMS '%s'." % rdbms)
+    raise Exception("Unknown RDBMS '{0!s}'.".format(rdbms))
 
 
 # ----------------------------------------------------------------------------------------------------------------------
@@ -84,7 +84,7 @@ def create_routine_wrapper_generator(rdbms):
         module = locate('pystratum.pgsql.PgSqlRoutineWrapperGenerator')
         return module.PgSqlRoutineWrapperGenerator()
 
-    raise Exception("Unknown RDBMS '%s'." % rdbms)
+    raise Exception("Unknown RDBMS '{0!s}'.".format(rdbms))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/mssql/MsSqlConstants.py
+++ b/pystratum/mssql/MsSqlConstants.py
@@ -169,14 +169,14 @@ order by  scm.name
                 for col_id, column_name in sorted(key_map.items()):
                     if table[column_name]['length'] is not None:
                         if 'constant_name' in table[column_name]:
-                            line_format = "%%s.%%s.%%-%ds %%%dd %%s\n" % (int(width1), int(width2))
+                            line_format = "%s.%s.%-{0:d}s %{1:d}d %s\n".format(int(width1), int(width2))
                             content += line_format % (schema_name,
                                                       table[column_name]['table_name'],
                                                       table[column_name]['column_name'],
                                                       table[column_name]['length'],
                                                       table[column_name]['constant_name'])
                         else:
-                            line_format = "%%s.%%s.%%-%ds %%%dd\n" % (int(width1), int(width2))
+                            line_format = "%s.%s.%-{0:d}s %{1:d}d\n".format(int(width1), int(width2))
                             content += line_format % (schema_name,
                                                       table[column_name]['table_name'],
                                                       table[column_name]['column_name'],
@@ -209,11 +209,10 @@ and   cl2.is_identity = 1"""
 
         for table in tables:
             query_string = """
-select tab.[%s] id
-,      tab.[%s] label
-from   [%s].[%s].[%s] tab
-where  nullif(tab.[%s],'') is not null""" \
-                           % (table['id'],
+select tab.[{0!s}] id
+,      tab.[{1!s}] label
+from   [{2!s}].[{3!s}].[{4!s}] tab
+where  nullif(tab.[{5!s}],'') is not null""".format(table['id'],
                               table['label'],
                               self._database,
                               table['schema_name'],
@@ -351,7 +350,7 @@ where  nullif(tab.[%s],'') is not null""" \
                 # This is a varchar(max) data type.
                 return 2147483647
 
-        raise Exception("Unexpected data type '%s'." % data_type)
+        raise Exception("Unexpected data type '{0!s}'.".format(data_type))
 
     # ------------------------------------------------------------------------------------------------------------------
     def _read_configuration_file(self, config_filename: str):

--- a/pystratum/mssql/MsSqlRoutineLoader.py
+++ b/pystratum/mssql/MsSqlRoutineLoader.py
@@ -47,7 +47,7 @@ order by  scm.name
         rows = StaticDataLayer.execute_rows(sql)
 
         for row in rows:
-            key = '@%s.%s.%s%%type@' % (row['schema_name'], row['table_name'], row['column_name'])
+            key = '@{0!s}.{1!s}.{2!s}%type@'.format(row['schema_name'], row['table_name'], row['column_name'])
             key = key.lower()
 
             value = self._derive_data_type(row)
@@ -99,13 +99,13 @@ and   prc.is_ms_shipped=0"""
         for routine_name, values in self._rdbms_old_metadata.items():
             if routine_name not in self._source_file_names:
                 if values['routine_type'].strip() == 'P':
-                    print("Dropping procedure %s.%s" % (values['schema_name'], values['routine_name']))
-                    sql = "drop procedure [%s].[%s]" % (values['schema_name'], values['routine_name'])
+                    print("Dropping procedure {0!s}.{1!s}".format(values['schema_name'], values['routine_name']))
+                    sql = "drop procedure [{0!s}].[{1!s}]".format(values['schema_name'], values['routine_name'])
                 elif values['routine_type'].strip() in ('FN', 'TF'):
-                    print("Dropping function %s.%s" % (values['schema_name'], values['routine_name']))
-                    sql = "drop function [%s].[%s]" % (values['schema_name'], values['routine_name'])
+                    print("Dropping function {0!s}.{1!s}".format(values['schema_name'], values['routine_name']))
+                    sql = "drop function [{0!s}].[{1!s}]".format(values['schema_name'], values['routine_name'])
                 else:
-                    raise Exception("Unknown routine type '%s'." % values['type'])
+                    raise Exception("Unknown routine type '{0!s}'.".format(values['type']))
 
                 StaticDataLayer.execute_none(sql)
 
@@ -141,10 +141,10 @@ and   prc.is_ms_shipped=0"""
             return data_type
 
         if data_type == 'decimal':
-            return 'decimal(%d,%d)' % (column['precision'], column['scale'])
+            return 'decimal({0:d},{1:d})'.format(column['precision'], column['scale'])
 
         if data_type == 'numeric':
-            return 'decimal(%d,%d)' % (column['precision'], column['scale'])
+            return 'decimal({0:d},{1:d})'.format(column['precision'], column['scale'])
 
         if data_type == 'float':
             return data_type
@@ -171,25 +171,25 @@ and   prc.is_ms_shipped=0"""
             return data_type
 
         if data_type == 'char':
-            return 'char(%d)' % column['max_length']
+            return 'char({0:d})'.format(column['max_length'])
 
         if data_type == 'varchar':
             if column['max_length'] == -1:
                 return 'varchar(max)'
 
-            return 'varchar(%d)' % column['max_length']
+            return 'varchar({0:d})'.format(column['max_length'])
 
         if data_type == 'text':
             return data_type
 
         if data_type == 'nchar':
-            return 'nchar(%d)' % (column['max_length'] / 2)
+            return 'nchar({0:d})'.format((column['max_length'] / 2))
 
         if data_type == 'nvarchar':
             if column['max_length'] == -1:
                 return 'nvarchar(max)'
 
-            return 'nvarchar(%d)' % (column['max_length'] / 2)
+            return 'nvarchar({0:d})'.format((column['max_length'] / 2))
 
         if data_type == 'ntext':
             return data_type
@@ -198,7 +198,7 @@ and   prc.is_ms_shipped=0"""
             return data_type
 
         if data_type == 'varbinary':
-            return 'varbinary(%d)' % column['max_length']
+            return 'varbinary({0:d})'.format(column['max_length'])
 
         if data_type == 'image':
             return data_type
@@ -212,7 +212,7 @@ and   prc.is_ms_shipped=0"""
         if data_type == 'geometry':
             return data_type
 
-        raise Exception("Unexpected data type '%s'." % data_type)
+        raise Exception("Unexpected data type '{0!s}'.".format(data_type))
 
     # ------------------------------------------------------------------------------------------------------------------
     def _read_configuration_file(self, config_filename: str):

--- a/pystratum/mssql/wrapper/FunctionsWrapper.py
+++ b/pystratum/mssql/wrapper/FunctionsWrapper.py
@@ -6,7 +6,7 @@ class FunctionsWrapper(MsSqlWrapper):
     # ------------------------------------------------------------------------------------------------------------------
     # select instead of call
     def _write_result_handler(self, routine):
-        self._write_line('return StaticDataLayer.execute_singleton1(%s)' % self._generate_command(routine))
+        self._write_line('return StaticDataLayer.execute_singleton1({0!s})'.format(self._generate_command(routine)))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/mssql/wrapper/LogWrapper.py
+++ b/pystratum/mssql/wrapper/LogWrapper.py
@@ -5,7 +5,7 @@ from pystratum.mssql.wrapper.MsSqlWrapper import MsSqlWrapper
 class LogWrapper(MsSqlWrapper):
     # ------------------------------------------------------------------------------------------------------------------
     def _write_result_handler(self, routine):
-        self._write_line('return StaticDataLayer.execute_log(%s)' % self._generate_command(routine))
+        self._write_line('return StaticDataLayer.execute_log({0!s})'.format(self._generate_command(routine)))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/mssql/wrapper/MsSqlWrapper.py
+++ b/pystratum/mssql/wrapper/MsSqlWrapper.py
@@ -52,7 +52,7 @@ class MsSqlWrapper(Wrapper):
                 if parameter_info['data_type'] in lookup:
                     has_blob = lookup[parameter_info['data_type']]
                 else:
-                    print("Unknown SQL type '%s'." % parameter_info['data_type'])
+                    print("Unknown SQL type '{0!s}'.".format(parameter_info['data_type']))
 
         return has_blob
 
@@ -62,7 +62,7 @@ class MsSqlWrapper(Wrapper):
         self._write_line()
         self._write_separator()
         self._write_line('@staticmethod')
-        self._write_line('def %s(%s):' % (str(routine['routine_base_name']), str(self._get_wrapper_args(routine))))
+        self._write_line('def {0!s}({1!s}):'.format(str(routine['routine_base_name']), str(self._get_wrapper_args(routine))))
         self._write_result_handler(routine)
 
         return self._code
@@ -155,7 +155,7 @@ class MsSqlWrapper(Wrapper):
         if data_type in lookup:
             return '%s'
 
-        raise Exception('Unexpected data type %s.' % data_type)
+        raise Exception('Unexpected data type {0!s}.'.format(data_type))
 
     # ------------------------------------------------------------------------------------------------------------------
     @staticmethod
@@ -196,7 +196,7 @@ class MsSqlWrapper(Wrapper):
         if data_type in templates:
             return templates[data_type]
 
-        raise Exception('Unexpected data type %s.' % data_type)
+        raise Exception('Unexpected data type {0!s}.'.format(data_type))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/mssql/wrapper/NoneWrapper.py
+++ b/pystratum/mssql/wrapper/NoneWrapper.py
@@ -5,7 +5,7 @@ from pystratum.mssql.wrapper.MsSqlWrapper import MsSqlWrapper
 class NoneWrapper(MsSqlWrapper):
     # ------------------------------------------------------------------------------------------------------------------
     def _write_result_handler(self, routine):
-        self._write_line('return StaticDataLayer.execute_none(%s)' % self._generate_command(routine))
+        self._write_line('return StaticDataLayer.execute_none({0!s})'.format(self._generate_command(routine)))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/mssql/wrapper/Row0Wrapper.py
+++ b/pystratum/mssql/wrapper/Row0Wrapper.py
@@ -5,7 +5,7 @@ from pystratum.mssql.wrapper.MsSqlWrapper import MsSqlWrapper
 class Row0Wrapper(MsSqlWrapper):
     # ------------------------------------------------------------------------------------------------------------------
     def _write_result_handler(self, routine):
-        self._write_line('return StaticDataLayer.execute_row0(%s)' % self._generate_command(routine))
+        self._write_line('return StaticDataLayer.execute_row0({0!s})'.format(self._generate_command(routine)))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/mssql/wrapper/Row1Wrapper.py
+++ b/pystratum/mssql/wrapper/Row1Wrapper.py
@@ -5,7 +5,7 @@ from pystratum.mssql.wrapper.MsSqlWrapper import MsSqlWrapper
 class Row1Wrapper(MsSqlWrapper):
     # ------------------------------------------------------------------------------------------------------------------
     def _write_result_handler(self, routine):
-        self._write_line('return StaticDataLayer.execute_row1(%s)' % self._generate_command(routine))
+        self._write_line('return StaticDataLayer.execute_row1({0!s})'.format(self._generate_command(routine)))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/mssql/wrapper/RowsWithIndexWrapper.py
+++ b/pystratum/mssql/wrapper/RowsWithIndexWrapper.py
@@ -6,6 +6,6 @@ from pystratum.wrapper.RowsWithIndexWrapper import RowsWithIndexWrapper as BaseR
 class RowsWithIndexWrapper(BaseRowsWithIndexWrapper, MsSqlWrapper):
     # ------------------------------------------------------------------------------------------------------------------
     def _write_execute_rows(self, routine):
-        self._write_line('rows = StaticDataLayer.execute_rows(%s)' % self._generate_command(routine))
+        self._write_line('rows = StaticDataLayer.execute_rows({0!s})'.format(self._generate_command(routine)))
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/mssql/wrapper/RowsWithKeyWrapper.py
+++ b/pystratum/mssql/wrapper/RowsWithKeyWrapper.py
@@ -7,7 +7,7 @@ class RowsWithKeyWrapper(BaseRowsWithKeyWrapper, MsSqlWrapper):
 
     # ------------------------------------------------------------------------------------------------------------------
     def _write_execute_rows(self, routine):
-        self._write_line('rows = StaticDataLayer.execute_rows(%s)' % self._generate_command(routine))
+        self._write_line('rows = StaticDataLayer.execute_rows({0!s})'.format(self._generate_command(routine)))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/mssql/wrapper/RowsWrapper.py
+++ b/pystratum/mssql/wrapper/RowsWrapper.py
@@ -5,7 +5,7 @@ from pystratum.mssql.wrapper.MsSqlWrapper import MsSqlWrapper
 class RowsWrapper(MsSqlWrapper):
     # ------------------------------------------------------------------------------------------------------------------
     def _write_result_handler(self, routine):
-        self._write_line('return StaticDataLayer.execute_rows(%s)' % self._generate_command(routine))
+        self._write_line('return StaticDataLayer.execute_rows({0!s})'.format(self._generate_command(routine)))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/mssql/wrapper/Singleton0Wrapper.py
+++ b/pystratum/mssql/wrapper/Singleton0Wrapper.py
@@ -5,7 +5,7 @@ from pystratum.mssql.wrapper.MsSqlWrapper import MsSqlWrapper
 class Singleton0Wrapper(MsSqlWrapper):
     # ------------------------------------------------------------------------------------------------------------------
     def _write_result_handler(self, routine):
-        self._write_line('return StaticDataLayer.execute_singleton0(%s)' % self._generate_command(routine))
+        self._write_line('return StaticDataLayer.execute_singleton0({0!s})'.format(self._generate_command(routine)))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/mssql/wrapper/Singleton1Wrapper.py
+++ b/pystratum/mssql/wrapper/Singleton1Wrapper.py
@@ -5,7 +5,7 @@ from pystratum.mssql.wrapper.MsSqlWrapper import MsSqlWrapper
 class Singleton1Wrapper(MsSqlWrapper):
     # ------------------------------------------------------------------------------------------------------------------
     def _write_result_handler(self, routine):
-        self._write_line('return StaticDataLayer.execute_singleton1(%s)' % str(self._generate_command(routine)))
+        self._write_line('return StaticDataLayer.execute_singleton1({0!s})'.format(str(self._generate_command(routine))))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/mssql/wrapper/TableWrapper.py
+++ b/pystratum/mssql/wrapper/TableWrapper.py
@@ -5,7 +5,7 @@ from pystratum.mssql.wrapper.MsSqlWrapper import MsSqlWrapper
 class TableWrapper(MsSqlWrapper):
     # ------------------------------------------------------------------------------------------------------------------
     def _write_result_handler(self, routine):
-        self._write_line('return StaticDataLayer.execute_table(%s)' % self._generate_command(routine))
+        self._write_line('return StaticDataLayer.execute_table({0!s})'.format(self._generate_command(routine)))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/mssql/wrapper/__init__.py
+++ b/pystratum/mssql/wrapper/__init__.py
@@ -43,7 +43,7 @@ def create_routine_wrapper(routine, lob_as_string_flag):
     #elif routine['designation'] == 'bulk_insert':
     #    wrapper = BulkInsertWrapper(routine, lob_as_string_flag)
     else:
-        raise Exception("Unknown routine type '%s'." % routine['designation'])
+        raise Exception("Unknown routine type '{0!s}'.".format(routine['designation']))
 
     return wrapper
 

--- a/pystratum/mysql/MySqlConstants.py
+++ b/pystratum/mysql/MySqlConstants.py
@@ -171,13 +171,13 @@ union all
             for ord_position, column_name in sorted(key_map.items()):
                 if table[column_name]['length'] is not None:
                     if 'constant_name' in table[column_name]:
-                        line_format = "%%s.%%-%ds %%%dd %%s\n" % (int(width1), int(width2))
+                        line_format = "%s.%-{0:d}s %{1:d}d %s\n".format(int(width1), int(width2))
                         content += line_format % (table[column_name]['table_name'],
                                                   table[column_name]['column_name'],
                                                   table[column_name]['length'],
                                                   table[column_name]['constant_name'])
                     else:
-                        line_format = "%%s.%%-%ds %%%dd\n" % (int(width1), int(width2))
+                        line_format = "%s.%-{0:d}s %{1:d}d\n".format(int(width1), int(width2))
                         content += line_format % (table[column_name]['table_name'],
                                                   table[column_name]['column_name'],
                                                   table[column_name]['length'])
@@ -207,10 +207,10 @@ and   t2.COLUMN_NAME like '%%\\_label'"""
 
         for table in tables:
             query_string = """
-select `%s`  as `id`
-,      `%s`  as `label`
-from   `%s`
-where   nullif(`%s`,'') is not null""" % (table['id'],
+select `{0!s}`  as `id`
+,      `{1!s}`  as `label`
+from   `{2!s}`
+where   nullif(`{3!s}`,'') is not null""".format(table['id'],
                                           table['label'],
                                           table['table_name'],
                                           table['label'])
@@ -272,7 +272,7 @@ where   nullif(`%s`,'') is not null""" % (table['id'],
         if the_column['data_type'] in types_length:
             return types_length[the_column['data_type']]
 
-        raise Exception("Unexpected type '%s'." % the_column['data_type'])
+        raise Exception("Unexpected type '{0!s}'.".format(the_column['data_type']))
 
     # ------------------------------------------------------------------------------------------------------------------
     def _read_configuration_file(self, config_filename: str):

--- a/pystratum/mysql/MySqlRoutineLoader.py
+++ b/pystratum/mysql/MySqlRoutineLoader.py
@@ -96,7 +96,7 @@ order by routine_name"""
         """
         Gets the SQL mode in the order as preferred by MySQL.
         """
-        sql = "set sql_mode = %s" % self._sql_mode
+        sql = "set sql_mode = {0!s}".format(self._sql_mode)
         StaticDataLayer.execute_none(sql)
 
         query = "select @@sql_mode;"
@@ -111,8 +111,8 @@ order by routine_name"""
         """
         for routine_name, values in self._rdbms_old_metadata.items():
             if routine_name not in self._source_file_names:
-                print("Dropping %s %s" % (values['routine_type'], routine_name))
-                sql = "drop %s if exists %s" % (values['routine_type'], routine_name)
+                print("Dropping {0!s} {1!s}".format(values['routine_type'], routine_name))
+                sql = "drop {0!s} if exists {1!s}".format(values['routine_type'], routine_name)
                 StaticDataLayer.execute_none(sql)
 
     # ------------------------------------------------------------------------------------------------------------------

--- a/pystratum/mysql/wrapper/FunctionsWrapper.py
+++ b/pystratum/mysql/wrapper/FunctionsWrapper.py
@@ -6,7 +6,7 @@ class FunctionsWrapper(MySqlWrapper):
     # ------------------------------------------------------------------------------------------------------------------
     # select instead of call
     def _write_result_handler(self, routine):
-        self._write_line('return StaticDataLayer.execute_singleton1(%s)' % self._generate_command(routine))
+        self._write_line('return StaticDataLayer.execute_singleton1({0!s})'.format(self._generate_command(routine)))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/mysql/wrapper/LogWrapper.py
+++ b/pystratum/mysql/wrapper/LogWrapper.py
@@ -5,7 +5,7 @@ from pystratum.mysql.wrapper.MySqlWrapper import MySqlWrapper
 class LogWrapper(MySqlWrapper):
     # ------------------------------------------------------------------------------------------------------------------
     def _write_result_handler(self, routine):
-        self._write_line('return StaticDataLayer.execute_sp_log(%s)' % self._generate_command(routine))
+        self._write_line('return StaticDataLayer.execute_sp_log({0!s})'.format(self._generate_command(routine)))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/mysql/wrapper/MySqlWrapper.py
+++ b/pystratum/mysql/wrapper/MySqlWrapper.py
@@ -52,7 +52,7 @@ class MySqlWrapper(Wrapper):
                 if parameter_info['data_type'] in lookup:
                     has_lob = lookup[parameter_info['data_type']]
                 else:
-                    raise Exception("Unexpected date type '%s'." % parameter_info['data_type'])
+                    raise Exception("Unexpected date type '{0!s}'.".format(parameter_info['data_type']))
 
         return has_lob
 
@@ -93,9 +93,9 @@ class MySqlWrapper(Wrapper):
                 l += 1
 
         if l == 0:
-            line = '"%s %s()"' % (execute, routine['routine_name'])
+            line = '"{0!s} {1!s}()"'.format(execute, routine['routine_name'])
         elif l >= 1:
-            line = '"%s %s(%s)", %s' % (execute, routine['routine_name'], placeholders, parameters)
+            line = '"{0!s} {1!s}({2!s})", {3!s}'.format(execute, routine['routine_name'], placeholders, parameters)
         else:
             raise Exception('Internal error.')
 
@@ -142,7 +142,7 @@ class MySqlWrapper(Wrapper):
         if data_type in lookup:
             return lookup[data_type]
 
-        raise Exception('Unexpected data type %s.' % data_type)
+        raise Exception('Unexpected data type {0!s}.'.format(data_type))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/mysql/wrapper/NoneWrapper.py
+++ b/pystratum/mysql/wrapper/NoneWrapper.py
@@ -5,7 +5,7 @@ from pystratum.mysql.wrapper.MySqlWrapper import MySqlWrapper
 class NoneWrapper(MySqlWrapper):
     # ------------------------------------------------------------------------------------------------------------------
     def _write_result_handler(self, routine):
-        self._write_line('return StaticDataLayer.execute_sp_none(%s)' % self._generate_command(routine))
+        self._write_line('return StaticDataLayer.execute_sp_none({0!s})'.format(self._generate_command(routine)))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/mysql/wrapper/Row0Wrapper.py
+++ b/pystratum/mysql/wrapper/Row0Wrapper.py
@@ -5,7 +5,7 @@ from pystratum.mysql.wrapper.MySqlWrapper import MySqlWrapper
 class Row0Wrapper(MySqlWrapper):
     # ------------------------------------------------------------------------------------------------------------------
     def _write_result_handler(self, routine):
-        self._write_line('return StaticDataLayer.execute_sp_row0(%s)' % self._generate_command(routine))
+        self._write_line('return StaticDataLayer.execute_sp_row0({0!s})'.format(self._generate_command(routine)))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/mysql/wrapper/Row1Wrapper.py
+++ b/pystratum/mysql/wrapper/Row1Wrapper.py
@@ -5,7 +5,7 @@ from pystratum.mysql.wrapper.MySqlWrapper import MySqlWrapper
 class Row1Wrapper(MySqlWrapper):
     # ------------------------------------------------------------------------------------------------------------------
     def _write_result_handler(self, routine):
-        self._write_line('return StaticDataLayer.execute_sp_row1(%s)' % self._generate_command(routine))
+        self._write_line('return StaticDataLayer.execute_sp_row1({0!s})'.format(self._generate_command(routine)))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/mysql/wrapper/RowsWithIndexWrapper.py
+++ b/pystratum/mysql/wrapper/RowsWithIndexWrapper.py
@@ -6,6 +6,6 @@ from pystratum.wrapper.RowsWithIndexWrapper import RowsWithIndexWrapper as BaseR
 class RowsWithIndexWrapper(BaseRowsWithIndexWrapper, MySqlWrapper):
     # ------------------------------------------------------------------------------------------------------------------
     def _write_execute_rows(self, routine):
-        self._write_line('rows = StaticDataLayer.execute_sp_rows(%s)' % self._generate_command(routine))
+        self._write_line('rows = StaticDataLayer.execute_sp_rows({0!s})'.format(self._generate_command(routine)))
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/mysql/wrapper/RowsWithKeyWrapper.py
+++ b/pystratum/mysql/wrapper/RowsWithKeyWrapper.py
@@ -7,7 +7,7 @@ class RowsWithKeyWrapper(BaseRowsWithKeyWrapper, MySqlWrapper):
 
     # ------------------------------------------------------------------------------------------------------------------
     def _write_execute_rows(self, routine):
-        self._write_line('rows = StaticDataLayer.execute_sp_rows(%s)' % self._generate_command(routine))
+        self._write_line('rows = StaticDataLayer.execute_sp_rows({0!s})'.format(self._generate_command(routine)))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/mysql/wrapper/RowsWrapper.py
+++ b/pystratum/mysql/wrapper/RowsWrapper.py
@@ -5,7 +5,7 @@ from pystratum.mysql.wrapper.MySqlWrapper import MySqlWrapper
 class RowsWrapper(MySqlWrapper):
     # ------------------------------------------------------------------------------------------------------------------
     def _write_result_handler(self, routine):
-        self._write_line('return StaticDataLayer.execute_sp_rows(%s)' % self._generate_command(routine))
+        self._write_line('return StaticDataLayer.execute_sp_rows({0!s})'.format(self._generate_command(routine)))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/mysql/wrapper/Singleton0Wrapper.py
+++ b/pystratum/mysql/wrapper/Singleton0Wrapper.py
@@ -5,7 +5,7 @@ from pystratum.mysql.wrapper.MySqlWrapper import MySqlWrapper
 class Singleton0Wrapper(MySqlWrapper):
     # ------------------------------------------------------------------------------------------------------------------
     def _write_result_handler(self, routine):
-        self._write_line('return StaticDataLayer.execute_sp_singleton0(%s)' % self._generate_command(routine))
+        self._write_line('return StaticDataLayer.execute_sp_singleton0({0!s})'.format(self._generate_command(routine)))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/mysql/wrapper/Singleton1Wrapper.py
+++ b/pystratum/mysql/wrapper/Singleton1Wrapper.py
@@ -5,7 +5,7 @@ from pystratum.mysql.wrapper.MySqlWrapper import MySqlWrapper
 class Singleton1Wrapper(MySqlWrapper):
     # ------------------------------------------------------------------------------------------------------------------
     def _write_result_handler(self, routine):
-        self._write_line('return StaticDataLayer.execute_sp_singleton1(%s)' % str(self._generate_command(routine)))
+        self._write_line('return StaticDataLayer.execute_sp_singleton1({0!s})'.format(str(self._generate_command(routine))))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/mysql/wrapper/TableWrapper.py
+++ b/pystratum/mysql/wrapper/TableWrapper.py
@@ -5,7 +5,7 @@ from pystratum.mysql.wrapper.MySqlWrapper import MySqlWrapper
 class TableWrapper(MySqlWrapper):
     # ------------------------------------------------------------------------------------------------------------------
     def _write_result_handler(self, routine):
-        self._write_line('return StaticDataLayer.execute_sp_table(%s)' % self._generate_command(routine))
+        self._write_line('return StaticDataLayer.execute_sp_table({0!s})'.format(self._generate_command(routine)))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/mysql/wrapper/__init__.py
+++ b/pystratum/mysql/wrapper/__init__.py
@@ -43,7 +43,7 @@ def create_routine_wrapper(routine, lob_as_string_flag):
     #elif routine['designation'] == 'bulk_insert':
     #    wrapper = BulkInsertWrapper(routine, lob_as_string_flag)
     else:
-        raise Exception("Unknown routine type '%s'." % routine['designation'])
+        raise Exception("Unknown routine type '{0!s}'.".format(routine['designation']))
 
     return wrapper
 

--- a/pystratum/pgsql/PgSqlConstants.py
+++ b/pystratum/pgsql/PgSqlConstants.py
@@ -172,13 +172,13 @@ union all
             for ord_position, column_name in sorted(key_map.items()):
                 if table[column_name]['length'] is not None:
                     if 'constant_name' in table[column_name]:
-                        line_format = "%%s.%%-%ds %%%dd %%s\n" % (int(width1), int(width2))
+                        line_format = "%s.%-{0:d}s %{1:d}d %s\n".format(int(width1), int(width2))
                         content += line_format % (table[column_name]['table_name'],
                                                   table[column_name]['column_name'],
                                                   table[column_name]['length'],
                                                   table[column_name]['constant_name'])
                     else:
-                        line_format = "%%s.%%-%ds %%%dd\n" % (int(width1), int(width2))
+                        line_format = "%s.%-{0:d}s %{1:d}d\n".format(int(width1), int(width2))
                         content += line_format % (table[column_name]['table_name'],
                                                   table[column_name]['column_name'],
                                                   table[column_name]['length'])
@@ -211,10 +211,10 @@ and   t2.column_name like '%%_label'
 
         for table in tables:
             query_string = """
-select \"%s\"  as id
-,      \"%s\"  as label
-from   \"%s\"
-where   nullif(\"%s\",'') is not null""" % (table['id'],
+select \"{0!s}\"  as id
+,      \"{1!s}\"  as label
+from   \"{2!s}\"
+where   nullif(\"{3!s}\",'') is not null""".format(table['id'],
                                             table['label'],
                                             table['table_name'],
                                             table['label'])
@@ -268,7 +268,7 @@ where   nullif(\"%s\",'') is not null""" % (table['id'],
         if column['data_type'] in types_length:
             return types_length[column['data_type']]
 
-        raise Exception("Unexpected type '%s'." % column['data_type'])
+        raise Exception("Unexpected type '{0!s}'.".format(column['data_type']))
 
     # ------------------------------------------------------------------------------------------------------------------
     def _read_configuration_file(self, config_filename):

--- a/pystratum/pgsql/PgSqlRoutineLoader.py
+++ b/pystratum/pgsql/PgSqlRoutineLoader.py
@@ -106,8 +106,8 @@ order by routine_name
         """
         for routine_name, values in self._rdbms_old_metadata.items():
             if routine_name not in self._source_file_names:
-                print("Dropping %s %s" % (values['routine_type'], routine_name))
-                sql = "drop %s if exists %s(%s)" % (values['routine_type'],
+                print("Dropping {0!s} {1!s}".format(values['routine_type'], routine_name))
+                sql = "drop {0!s} if exists {1!s}({2!s})".format(values['routine_type'],
                                                     routine_name,
                                                     values['routine_args'])
                 StaticDataLayer.execute_none(sql)

--- a/pystratum/pgsql/StaticDataLayer.py
+++ b/pystratum/pgsql/StaticDataLayer.py
@@ -182,8 +182,7 @@ class StaticDataLayer:
         cursor.close()
 
         if not (n == 0 or n == 1):
-            raise Exception("Number of rows selected by query below is %d. Expected 0 or 1.\n%s" %
-                            (n, sql))
+            raise Exception("Number of rows selected by query below is {0:d}. Expected 0 or 1.\n{1!s}".format(n, sql))
 
         return ret
 
@@ -215,8 +214,7 @@ class StaticDataLayer:
         cursor.close()
 
         if n != 1:
-            raise Exception("Number of rows selected by query below is %d. Expected 1.\n%s" %
-                            (n, sql))
+            raise Exception("Number of rows selected by query below is {0:d}. Expected 1.\n{1!s}".format(n, sql))
 
         return ret
 
@@ -273,8 +271,7 @@ class StaticDataLayer:
         cursor.close()
 
         if not (n == 0 or n == 1):
-            raise Exception("Number of rows selected by query below is %d. Expected 0 or 1.\n%s" %
-                            (n, sql))
+            raise Exception("Number of rows selected by query below is {0:d}. Expected 0 or 1.\n{1!s}".format(n, sql))
 
         return ret
 
@@ -301,8 +298,7 @@ class StaticDataLayer:
         cursor.close()
 
         if n != 1:
-            raise Exception("Number of rows selected by query below is %d. Expected 1.\n%s" %
-                            (n, sql))
+            raise Exception("Number of rows selected by query below is {0:d}. Expected 1.\n{1!s}".format(n, sql))
 
         return ret
 
@@ -332,8 +328,7 @@ class StaticDataLayer:
         cursor.close()
 
         if len(rows) != 1:
-            raise Exception("Number of rows selected by query below is %d. Expected 1.\n%s" %
-                            (n, sql))
+            raise Exception("Number of rows selected by query below is {0:d}. Expected 1.\n{1!s}".format(n, sql))
 
         return ret
 
@@ -373,7 +368,7 @@ class StaticDataLayer:
 
         # Log the log messages.
         for message in messages:
-            print('%s %s' % message)
+            print('{0!s} {1!s}'.format(*message))
 
         return len(messages)
 

--- a/pystratum/pgsql/wrapper/FunctionsWrapper.py
+++ b/pystratum/pgsql/wrapper/FunctionsWrapper.py
@@ -6,7 +6,7 @@ class FunctionsWrapper(PgSqlWrapper):
     # ------------------------------------------------------------------------------------------------------------------
     # select instead of call
     def _write_result_handler(self, routine):
-        self._write_line('return StaticDataLayer.execute_singleton1(%s)' % self._generate_command(routine))
+        self._write_line('return StaticDataLayer.execute_singleton1({0!s})'.format(self._generate_command(routine)))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/pgsql/wrapper/LogWrapper.py
+++ b/pystratum/pgsql/wrapper/LogWrapper.py
@@ -5,7 +5,7 @@ from pystratum.pgsql.wrapper.PgSqlWrapper import PgSqlWrapper
 class LogWrapper(PgSqlWrapper):
     # ------------------------------------------------------------------------------------------------------------------
     def _write_result_handler(self, routine):
-        self._write_line('return StaticDataLayer.execute_sp_log(%s)' % self._generate_command(routine))
+        self._write_line('return StaticDataLayer.execute_sp_log({0!s})'.format(self._generate_command(routine)))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/pgsql/wrapper/NoneWrapper.py
+++ b/pystratum/pgsql/wrapper/NoneWrapper.py
@@ -5,7 +5,7 @@ from pystratum.pgsql.wrapper.PgSqlWrapper import PgSqlWrapper
 class NoneWrapper(PgSqlWrapper):
     # ------------------------------------------------------------------------------------------------------------------
     def _write_result_handler(self, routine):
-        self._write_line('return StaticDataLayer.execute_sp_none(%s)' % self._generate_command(routine))
+        self._write_line('return StaticDataLayer.execute_sp_none({0!s})'.format(self._generate_command(routine)))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/pgsql/wrapper/PgSqlWrapper.py
+++ b/pystratum/pgsql/wrapper/PgSqlWrapper.py
@@ -40,7 +40,7 @@ class PgSqlWrapper(Wrapper):
                 if parameter_info['data_type'] in lookup:
                     has_lob = lookup[parameter_info['data_type']]
                 else:
-                    raise Exception("Unexpected date type '%s'." % parameter_info['data_type'])
+                    raise Exception("Unexpected date type '{0!s}'.".format(parameter_info['data_type']))
 
         return has_lob
 
@@ -79,9 +79,9 @@ class PgSqlWrapper(Wrapper):
                 l += 1
 
         if l == 0:
-            line = '"%s %s()"' % (execute, routine['routine_name'])
+            line = '"{0!s} {1!s}()"'.format(execute, routine['routine_name'])
         elif l >= 1:
-            line = '"%s %s(%s)", %s' % (execute, routine['routine_name'], placeholders, parameters)
+            line = '"{0!s} {1!s}({2!s})", {3!s}'.format(execute, routine['routine_name'], placeholders, parameters)
         else:
             raise Exception('Internal error.')
 
@@ -116,6 +116,6 @@ class PgSqlWrapper(Wrapper):
         if parameter['data_type'] in lookup:
             return lookup[parameter['data_type']]
 
-        raise Exception('Unexpected data type %s.' % parameter['data_type'])
+        raise Exception('Unexpected data type {0!s}.'.format(parameter['data_type']))
 
 # ---------------------------------------------------------------------------------------------------------------------

--- a/pystratum/pgsql/wrapper/Row0Wrapper.py
+++ b/pystratum/pgsql/wrapper/Row0Wrapper.py
@@ -5,7 +5,7 @@ from pystratum.pgsql.wrapper.PgSqlWrapper import PgSqlWrapper
 class Row0Wrapper(PgSqlWrapper):
     # ------------------------------------------------------------------------------------------------------------------
     def _write_result_handler(self, routine):
-        self._write_line('return StaticDataLayer.execute_sp_row0(%s)' % self._generate_command(routine))
+        self._write_line('return StaticDataLayer.execute_sp_row0({0!s})'.format(self._generate_command(routine)))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/pgsql/wrapper/Row1Wrapper.py
+++ b/pystratum/pgsql/wrapper/Row1Wrapper.py
@@ -5,7 +5,7 @@ from pystratum.pgsql.wrapper.PgSqlWrapper import PgSqlWrapper
 class Row1Wrapper(PgSqlWrapper):
     # ------------------------------------------------------------------------------------------------------------------
     def _write_result_handler(self, routine):
-        self._write_line('return StaticDataLayer.execute_sp_row1(%s)' % self._generate_command(routine))
+        self._write_line('return StaticDataLayer.execute_sp_row1({0!s})'.format(self._generate_command(routine)))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/pgsql/wrapper/RowsWithIndexWrapper.py
+++ b/pystratum/pgsql/wrapper/RowsWithIndexWrapper.py
@@ -6,6 +6,6 @@ from pystratum.wrapper.RowsWithIndexWrapper import RowsWithIndexWrapper as BaseR
 class RowsWithIndexWrapper(BaseRowsWithIndexWrapper, PgSqlWrapper):
     # ------------------------------------------------------------------------------------------------------------------
     def _write_execute_rows(self, routine):
-        self._write_line('rows = StaticDataLayer.execute_sp_rows(%s)' % self._generate_command(routine))
+        self._write_line('rows = StaticDataLayer.execute_sp_rows({0!s})'.format(self._generate_command(routine)))
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/pgsql/wrapper/RowsWithKeyWrapper.py
+++ b/pystratum/pgsql/wrapper/RowsWithKeyWrapper.py
@@ -7,7 +7,7 @@ class RowsWithKeyWrapper(BaseRowsWithKeyWrapper, PgSqlWrapper):
 
     # ------------------------------------------------------------------------------------------------------------------
     def _write_execute_rows(self, routine):
-        self._write_line('rows = StaticDataLayer.execute_sp_rows(%s)' % self._generate_command(routine))
+        self._write_line('rows = StaticDataLayer.execute_sp_rows({0!s})'.format(self._generate_command(routine)))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/pgsql/wrapper/RowsWrapper.py
+++ b/pystratum/pgsql/wrapper/RowsWrapper.py
@@ -5,7 +5,7 @@ from pystratum.pgsql.wrapper.PgSqlWrapper import PgSqlWrapper
 class RowsWrapper(PgSqlWrapper):
     # ------------------------------------------------------------------------------------------------------------------
     def _write_result_handler(self, routine):
-        self._write_line('return StaticDataLayer.execute_sp_rows(%s)' % self._generate_command(routine))
+        self._write_line('return StaticDataLayer.execute_sp_rows({0!s})'.format(self._generate_command(routine)))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/pgsql/wrapper/Singleton0Wrapper.py
+++ b/pystratum/pgsql/wrapper/Singleton0Wrapper.py
@@ -5,7 +5,7 @@ from pystratum.pgsql.wrapper.PgSqlWrapper import PgSqlWrapper
 class Singleton0Wrapper(PgSqlWrapper):
     # ------------------------------------------------------------------------------------------------------------------
     def _write_result_handler(self, routine):
-        self._write_line('return StaticDataLayer.execute_sp_singleton0(%s)' % self._generate_command(routine))
+        self._write_line('return StaticDataLayer.execute_sp_singleton0({0!s})'.format(self._generate_command(routine)))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/pgsql/wrapper/Singleton1Wrapper.py
+++ b/pystratum/pgsql/wrapper/Singleton1Wrapper.py
@@ -5,7 +5,7 @@ from pystratum.pgsql.wrapper.PgSqlWrapper import PgSqlWrapper
 class Singleton1Wrapper(PgSqlWrapper):
     # ------------------------------------------------------------------------------------------------------------------
     def _write_result_handler(self, routine):
-        self._write_line('return StaticDataLayer.execute_sp_singleton1(%s)' % str(self._generate_command(routine)))
+        self._write_line('return StaticDataLayer.execute_sp_singleton1({0!s})'.format(str(self._generate_command(routine))))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/pgsql/wrapper/TableWrapper.py
+++ b/pystratum/pgsql/wrapper/TableWrapper.py
@@ -5,7 +5,7 @@ from pystratum.pgsql.wrapper.PgSqlWrapper import PgSqlWrapper
 class TableWrapper(PgSqlWrapper):
     # ------------------------------------------------------------------------------------------------------------------
     def _write_result_handler(self, routine):
-        self._write_line('return StaticDataLayer.execute_sp_table(%s)' % self._generate_command(routine))
+        self._write_line('return StaticDataLayer.execute_sp_table({0!s})'.format(self._generate_command(routine)))
 
 
 # ----------------------------------------------------------------------------------------------------------------------

--- a/pystratum/pgsql/wrapper/__init__.py
+++ b/pystratum/pgsql/wrapper/__init__.py
@@ -43,7 +43,7 @@ def create_routine_wrapper(routine, lob_as_string_flag):
     #elif routine['designation'] == 'bulk_insert':
     #    wrapper = BulkInsertWrapper(routine, lob_as_string_flag)
     else:
-        raise Exception("Unknown routine type '%s'." % routine['designation'])
+        raise Exception("Unknown routine type '{0!s}'.".format(routine['designation']))
 
     return wrapper
 

--- a/pystratum/wrapper/RowsWithIndexWrapper.py
+++ b/pystratum/wrapper/RowsWithIndexWrapper.py
@@ -20,20 +20,20 @@ class RowsWithIndexWrapper(Wrapper):
 
         i = 0
         while i < num_of_dict:
-            value = "row['%s']" % routine['columns'][i]
+            value = "row['{0!s}']".format(routine['columns'][i])
 
             stack = ''
             j = 0
             while j < i:
-                stack += "[row['%s']]" % routine['columns'][j]
+                stack += "[row['{0!s}']]".format(routine['columns'][j])
                 j += 1
-            line = 'if %s in ret%s:' % (value, stack)
+            line = 'if {0!s} in ret{1!s}:'.format(value, stack)
             self._write_line(line)
             i += 1
 
         line = 'ret'
         for column_name in routine['columns']:
-            line += "[row['%s']]" % column_name
+            line += "[row['{0!s}']]".format(column_name)
         line += '.append(row)'
         self._write_line(line)
         self._indent_level_down()
@@ -45,19 +45,19 @@ class RowsWithIndexWrapper(Wrapper):
             part1 = ''
             j = 0
             while j < i - 1:
-                part1 += "[row['%s']]" % routine['columns'][j]
+                part1 += "[row['{0!s}']]".format(routine['columns'][j])
                 j += 1
-            part1 += "[row['%s']]" % routine['columns'][j]
+            part1 += "[row['{0!s}']]".format(routine['columns'][j])
 
             part2 = ''
             j = i - 1
             while j < num_of_dict:
                 if j + 1 != i:
-                    part2 += "{row['%s']: " % routine['columns'][j]
+                    part2 += "{{row['{0!s}']: ".format(routine['columns'][j])
                 j += 1
             part2 += "[row]" + ('}' * (num_of_dict - i))
 
-            line = "ret%s = %s" % (part1, part2)
+            line = "ret{0!s} = {1!s}".format(part1, part2)
             self._write_line(line)
             self._indent_level_down()
             if i > 1:

--- a/pystratum/wrapper/RowsWithKeyWrapper.py
+++ b/pystratum/wrapper/RowsWithKeyWrapper.py
@@ -20,19 +20,19 @@ class RowsWithKeyWrapper(Wrapper):
 
         i = 0
         while i < num_of_dict:
-            value = "row['%s']" % routine['columns'][i]
+            value = "row['{0!s}']".format(routine['columns'][i])
 
             stack = ''
             j = 0
             while j < i:
-                stack += "[row['%s']]" % routine['columns'][j]
+                stack += "[row['{0!s}']]".format(routine['columns'][j])
                 j += 1
-            line = 'if %s in ret%s:' % (value, stack)
+            line = 'if {0!s} in ret{1!s}:'.format(value, stack)
             self._write_line(line)
             i += 1
 
-        line = "raise Exception('Duplicate key for %%s.' %% str((%s)))" %\
-               ", ".join(["row['%s']" % column_name for column_name in routine['columns']])
+        line = "raise Exception('Duplicate key for %s.' % str(({0!s})))".format(\
+               ", ".join(["row['{0!s}']".format(column_name) for column_name in routine['columns']]))
 
         self._write_line(line)
         self._indent_level_down()
@@ -44,19 +44,19 @@ class RowsWithKeyWrapper(Wrapper):
             part1 = ''
             j = 0
             while j < i - 1:
-                part1 += "[row['%s']]" % routine['columns'][j]
+                part1 += "[row['{0!s}']]".format(routine['columns'][j])
                 j += 1
-            part1 += "[row['%s']]" % routine['columns'][j]
+            part1 += "[row['{0!s}']]".format(routine['columns'][j])
 
             part2 = ''
             j = i - 1
             while j < num_of_dict:
                 if j + 1 != i:
-                    part2 += "{row['%s']: " % routine['columns'][j]
+                    part2 += "{{row['{0!s}']: ".format(routine['columns'][j])
                 j += 1
             part2 += "row" + ('}' * (num_of_dict - i))
 
-            line = "ret%s = %s" % (part1, part2)
+            line = "ret{0!s} = {1!s}".format(part1, part2)
             self._write_line(line)
             self._indent_level_down()
             if i > 1:

--- a/pystratum/wrapper/Wrapper.py
+++ b/pystratum/wrapper/Wrapper.py
@@ -121,7 +121,7 @@ class Wrapper:
         self._write_line()
         self._write_separator()
         self._write_line('@staticmethod')
-        self._write_line('def %s(%s):' % (str(routine['routine_name']), str(self._get_wrapper_args(routine))))
+        self._write_line('def {0!s}({1!s}):'.format(str(routine['routine_name']), str(self._get_wrapper_args(routine))))
         self._write_result_handler(routine)
 
         return self._code

--- a/test/mssql/DataLayer.py
+++ b/test/mssql/DataLayer.py
@@ -74,7 +74,7 @@ class DataLayer(StaticDataLayer):
             if row['tst_c01'] in ret:
                 if row['tst_c02'] in ret[row['tst_c01']]:
                     if row['tst_c03'] in ret[row['tst_c01']][row['tst_c02']]:
-                        raise Exception('Duplicate key for %s.' % str((row['tst_c01'], row['tst_c02'], row['tst_c03'])))
+                        raise Exception('Duplicate key for {0!s}.'.format(str((row['tst_c01'], row['tst_c02'], row['tst_c03']))))
                     else:
                         ret[row['tst_c01']][row['tst_c02']][row['tst_c03']] = row
                 else:

--- a/test/mysql/DataLayer.py
+++ b/test/mysql/DataLayer.py
@@ -135,7 +135,7 @@ class DataLayer(StaticDataLayer):
             if row['tst_c01'] in ret:
                 if row['tst_c02'] in ret[row['tst_c01']]:
                     if row['tst_c03'] in ret[row['tst_c01']][row['tst_c02']]:
-                        raise Exception('Duplicate key for %s.' % str((row['tst_c01'], row['tst_c02'], row['tst_c03'])))
+                        raise Exception('Duplicate key for {0!s}.'.format(str((row['tst_c01'], row['tst_c02'], row['tst_c03']))))
                     else:
                         ret[row['tst_c01']][row['tst_c02']][row['tst_c03']] = row
                 else:
@@ -154,7 +154,7 @@ class DataLayer(StaticDataLayer):
             if row['tst_c01'] in ret:
                 if row['tst_c02'] in ret[row['tst_c01']]:
                     if row['tst_c03'] in ret[row['tst_c01']][row['tst_c02']]:
-                        raise Exception('Duplicate key for %s.' % str((row['tst_c01'], row['tst_c02'], row['tst_c03'])))
+                        raise Exception('Duplicate key for {0!s}.'.format(str((row['tst_c01'], row['tst_c02'], row['tst_c03']))))
                     else:
                         ret[row['tst_c01']][row['tst_c02']][row['tst_c03']] = row
                 else:

--- a/test/pgsql/DataLayer.py
+++ b/test/pgsql/DataLayer.py
@@ -200,7 +200,7 @@ class DataLayer(StaticDataLayer):
             if row['tst_c01'] in ret:
                 if row['tst_c02'] in ret[row['tst_c01']]:
                     if row['tst_c03'] in ret[row['tst_c01']][row['tst_c02']]:
-                        raise Exception('Duplicate key for %s.' % str((row['tst_c01'], row['tst_c02'], row['tst_c03'])))
+                        raise Exception('Duplicate key for {0!s}.'.format(str((row['tst_c01'], row['tst_c02'], row['tst_c03']))))
                     else:
                         ret[row['tst_c01']][row['tst_c02']][row['tst_c03']] = row
                 else:
@@ -219,7 +219,7 @@ class DataLayer(StaticDataLayer):
             if row['tst_c01'] in ret:
                 if row['tst_c02'] in ret[row['tst_c01']]:
                     if row['tst_c03'] in ret[row['tst_c01']][row['tst_c02']]:
-                        raise Exception('Duplicate key for %s.' % str((row['tst_c01'], row['tst_c02'], row['tst_c03'])))
+                        raise Exception('Duplicate key for {0!s}.'.format(str((row['tst_c01'], row['tst_c02'], row['tst_c03']))))
                     else:
                         ret[row['tst_c01']][row['tst_c02']][row['tst_c03']] = row
                 else:


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:SetBased:py-stratum?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:SetBased:py-stratum?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
