### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/test/mysql/DataLayer.py
+++ b/test/mysql/DataLayer.py
@@ -135,7 +135,7 @@ class DataLayer(StaticDataLayer):
             if row['tst_c01'] in ret:
                 if row['tst_c02'] in ret[row['tst_c01']]:
                     if row['tst_c03'] in ret[row['tst_c01']][row['tst_c02']]:
-                        raise Exception('Duplicate key for %s.' % str((row['tst_c01'], row['tst_c02'], row['tst_c03'])))
+                        raise Exception('Duplicate key for {0!s}.'.format(str((row['tst_c01'], row['tst_c02'], row['tst_c03']))))
                     else:
                         ret[row['tst_c01']][row['tst_c02']][row['tst_c03']] = row
                 else:
@@ -154,7 +154,7 @@ class DataLayer(StaticDataLayer):
             if row['tst_c01'] in ret:
                 if row['tst_c02'] in ret[row['tst_c01']]:
                     if row['tst_c03'] in ret[row['tst_c01']][row['tst_c02']]:
-                        raise Exception('Duplicate key for %s.' % str((row['tst_c01'], row['tst_c02'], row['tst_c03'])))
+                        raise Exception('Duplicate key for {0!s}.'.format(str((row['tst_c01'], row['tst_c02'], row['tst_c03']))))
                     else:
                         ret[row['tst_c01']][row['tst_c02']][row['tst_c03']] = row
                 else:

--- a/test/pgsql/DataLayer.py
+++ b/test/pgsql/DataLayer.py
@@ -200,7 +200,7 @@ class DataLayer(StaticDataLayer):
             if row['tst_c01'] in ret:
                 if row['tst_c02'] in ret[row['tst_c01']]:
                     if row['tst_c03'] in ret[row['tst_c01']][row['tst_c02']]:
-                        raise Exception('Duplicate key for %s.' % str((row['tst_c01'], row['tst_c02'], row['tst_c03'])))
+                        raise Exception('Duplicate key for {0!s}.'.format(str((row['tst_c01'], row['tst_c02'], row['tst_c03']))))
                     else:
                         ret[row['tst_c01']][row['tst_c02']][row['tst_c03']] = row
                 else:
@@ -219,7 +219,7 @@ class DataLayer(StaticDataLayer):
             if row['tst_c01'] in ret:
                 if row['tst_c02'] in ret[row['tst_c01']]:
                     if row['tst_c03'] in ret[row['tst_c01']][row['tst_c02']]:
-                        raise Exception('Duplicate key for %s.' % str((row['tst_c01'], row['tst_c02'], row['tst_c03'])))
+                        raise Exception('Duplicate key for {0!s}.'.format(str((row['tst_c01'], row['tst_c02'], row['tst_c03']))))
                     else:
                         ret[row['tst_c01']][row['tst_c02']][row['tst_c03']] = row
                 else:


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:SetBased:py-stratum?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:SetBased:py-stratum?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
